### PR TITLE
Fix CI, and fix the checksums for the SuiteSparse.jl external stdlib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,14 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         version:
+          - '1.6'
           - '1'
-          - 'nightly'
+          # - 'nightly'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,20 +1,23 @@
 name = "BumpStdlibs"
 uuid = "10e0400f-8273-43d0-bd6e-07483373ba4f"
 authors = ["Dilum Aluthge", "contributors"]
-version = "4.0.1"
+version = "4.1.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [compat]
 GitHub = "5.2"
 HTTP = "0.9"
-URIs = "1.1"
+JSON3 = "1.9"
 TimeZones = "1.5.2"
+URIs = "1.1"
 julia = "1.6"
 
 [extras]

--- a/src/BumpStdlibs.jl
+++ b/src/BumpStdlibs.jl
@@ -1,8 +1,10 @@
 module BumpStdlibs
 
 import Dates
+import Downloads
 import GitHub
 import HTTP
+import JSON3
 import TimeZones
 import URIs
 


### PR DESCRIPTION
1. Correctly pack the checksums for the SuiteSparse external stdlib
2. Use `Downloads.download` to get the user's GitHub username
3. Bump the version number from 4.0.1 to 4.1.0