### PR TITLE
Docs: add a footnote explaining how to get to the page for triggering the workflow dispatch event

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BumpStdlibs"
 uuid = "10e0400f-8273-43d0-bd6e-07483373ba4f"
 authors = ["Dilum Aluthge", "contributors"]
-version = "4.3.0"
+version = "4.3.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -6,7 +6,7 @@ CurrentModule = BumpStdlibs
 
 If you are a `JuliaLang` committer, and you want to run
 the BumpStdlibs action now, here are the steps:
-1. Go to [this URL](https://github.com/JuliaLang/BumpStdlibs.jl/actions/workflows/BumpStdlibs.yml).
+1. Go to [this URL](https://github.com/JuliaLang/BumpStdlibs.jl/actions/workflows/BumpStdlibs.yml).[^1]
 2. In the section that says "This workflow has a `workflow_dispatch` event trigger", click on the `Run workflow` button.
 3. Under "Use workflow from", make sure that you have selected the `master` branch
 4. Under "Comma-separated list of stdlibs to include":
@@ -15,3 +15,5 @@ the BumpStdlibs action now, here are the steps:
         - `Pkg`
         - `Downloads,Statistics,Tar`
 5. Click on the green `Run workflow` button.
+
+[^1]: If that link does not work, go to the [BumpStdlibs.jl repository](https://github.com/JuliaLang/BumpStdlibs.jl), click on the [Actions tab](https://github.com/JuliaLang/BumpStdlibs.jl/actions), and then click on "BumpStdlibs" (in the left-hand sidebar, under "Workflows").


### PR DESCRIPTION
For convenience, we have a "this URL" link that users can click to quickly get to the right page. However, if for some reason GitHub changes the URL format in the future, that link will break. So this PR adds a footnote that explains the steps that a user can follow to manually get to the right page.