### PR TITLE
Support updating non-`master` Julia branches (such as `backports-release-1.9`)

### DIFF
--- a/.github/workflows/BumpStdlibs.yml
+++ b/.github/workflows/BumpStdlibs.yml
@@ -2,18 +2,24 @@ name: BumpStdlibs
 on:
   workflow_dispatch:
     inputs:
+      BUMPSTDLIBS_TARGET_BRANCH:
+        description: 'Target branch (in the JuliaLang/julia) to target. Examples include master, backports-release-1.9, etc.'
+        required: true
+        default: 'master'
       BUMPSTDLIBS_STDLIBS_TO_INCLUDE:
         description: 'Comma-separated list of stdlibs to include like "Pkg,Downloads", or "all" for all:'
-        required: false
+        required: true
         default: 'all'
       BUMPSTDLIBS_CLOSE_OLD_PULL_REQUESTS:
-        description: 'Close outdated pull requests: (true/false)'
-        required: false
-        default: 'true'
+        description: 'Close outdated pull requests. Default: yes'
+        type: boolean
+        required: true
+        default: true
       BUMPSTDLIBS_PUSH_IF_NO_CHANGES:
-        description: 'Push (and retrigger CI) even if there are no changes: (true/false)'
-        required: false
-        default: 'false'
+        description: 'Push (and retrigger CI) even if there are no changes. Default: no'
+        type: boolean
+        required: true
+        default: false
 jobs:
   BumpStdlibs:
     if: github.event_name == 'workflow_dispatch'
@@ -28,7 +34,8 @@ jobs:
         env:
           BUMPSTDLIBS_CLOSE_OLD_PULL_REQUESTS: ${{ github.event.inputs.BUMPSTDLIBS_CLOSE_OLD_PULL_REQUESTS }}
           BUMPSTDLIBS_PUSH_IF_NO_CHANGES: ${{ github.event.inputs.BUMPSTDLIBS_PUSH_IF_NO_CHANGES }}
-          BUMPSTDLIBS_STDLIBS_TO_INCLUDE: ${{ github.event.inputs.BUMPSTDLIBS_STDLIBS_TO_INCLUDE }}
-          BUMPSTDLIBS_TOKEN: ${{ secrets.BUMPSTDLIBS_TOKEN }}
           BUMPSTDLIBS_SENDER: ${{ github.event.sender.login }}
+          BUMPSTDLIBS_STDLIBS_TO_INCLUDE: ${{ github.event.inputs.BUMPSTDLIBS_STDLIBS_TO_INCLUDE }}
+          BUMPSTDLIBS_TARGET_BRANCH: ${{ github.event.inputs.BUMPSTDLIBS_TARGET_BRANCH }}
+          BUMPSTDLIBS_TOKEN: ${{ secrets.BUMPSTDLIBS_TOKEN }}
           JULIA_DEBUG: 'all'

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BumpStdlibs"
 uuid = "10e0400f-8273-43d0-bd6e-07483373ba4f"
 authors = ["Dilum Aluthge", "contributors"]
-version = "5.1.0"
+version = "6.0.0-DEV"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -9,11 +9,12 @@ the BumpStdlibs action now, here are the steps:
 1. Go to [this URL](https://github.com/JuliaLang/BumpStdlibs.jl/actions/workflows/BumpStdlibs.yml).[^1]
 2. In the section that says "This workflow has a `workflow_dispatch` event trigger", click on the `Run workflow` button.
 3. Under "Use workflow from", make sure that you have selected the `master` branch
-4. Under "Comma-separated list of stdlibs to include":
+4. Under "Target branch", enter `master` if you want to target the Julia master branch, or enter e.g. `backports-release-1.9` if you want to apply these changes to the Julia 1.9 release branch.
+5. Under "Comma-separated list of stdlibs to include":
     - If you want to update all stdlibs, you can leave the default value of `all`
     - If you only want to update a selected set of stdlibs, enter the list, comma-separated. For example:
         - `Pkg`
         - `Downloads,Statistics,Tar`
-5. Click on the green `Run workflow` button.
+6. Click on the green `Run workflow` button.
 
 [^1]: If that link does not work, go to the [BumpStdlibs.jl repository](https://github.com/JuliaLang/BumpStdlibs.jl), click on the [Actions tab](https://github.com/JuliaLang/BumpStdlibs.jl/actions), and then click on "BumpStdlibs" (in the left-hand sidebar, under "Workflows").

--- a/src/types.jl
+++ b/src/types.jl
@@ -15,19 +15,18 @@ Base.@kwdef struct StdlibInfo
     current_shas::Dict{String, String}
 end
 
-Base.@kwdef struct Config{C1 <: GitHub.Authorization, C2 <: Bool, C3 <: Dates.AbstractTime, C4 <: AbstractString, C5 <: Bool, C6 <: Union{AbstractString, Nothing}, C7 <: Union{AbstractString, AbstractVector{<:AbstractString}}}
-    auth::C1 = get_input_from_environment(:auth)
-    close_old_pull_requests::C2 = get_input_from_environment(:close_old_pull_requests)
-    close_old_pull_requests_older_than::C3 = Dates.Minute(0)
-    pr_branch_suffix::C4 = ""
-    push_if_no_changes::C5 = get_input_from_environment(:push_if_no_changes)
-    julia_repo_default_branch::C6 = nothing
-    stdlibs_to_include::C7 = get_input_from_environment(:stdlibs_to_include)
+Base.@kwdef struct Config
+    auth::GitHub.Authorization = get_input_from_environment(:auth)
+    close_old_pull_requests::Bool = get_input_from_environment(:close_old_pull_requests)
+    close_old_pull_requests_older_than::Dates.AbstractTime = Dates.Minute(0)
+    julia_repo_target_branch::String = get_input_from_environment(:target_branch)
+    pr_branch_suffix::String = ""
+    push_if_no_changes::Bool = get_input_from_environment(:push_if_no_changes)
+    stdlibs_to_include::Union{String, Vector{String}} = get_input_from_environment(:stdlibs_to_include)
 end
 
-Base.@kwdef struct State{S1 <: AbstractVector{<:AbstractString}, S2 <: GitHub.Repo, S3 <:AbstractString, S4 <: GitHub.Repo}
-    all_pr_branches::S1 = String[]
-    fork_julia_repo_gh::S2
-    upstream_julia_repo_default_branch::S3
-    upstream_julia_repo_gh::S4
+Base.@kwdef struct State
+    all_pr_branches::Vector{String} = String[]
+    fork_julia_repo_gh::GitHub.Repo
+    upstream_julia_repo_gh::GitHub.Repo
 end

--- a/test/integration-tests.jl
+++ b/test/integration-tests.jl
@@ -5,6 +5,7 @@
         :auth => BumpStdlibs.get_input_from_environment(:auth, "BUMPSTDLIBS_TOKEN_FOR_TESTS"),
         :close_old_pull_requests => true,
         :close_old_pull_requests_older_than => Dates.Minute(5),
+        :julia_repo_target_branch => "master",
         :pr_branch_suffix => Random.randstring(4),
         :push_if_no_changes => true,
         :stdlibs_to_include => "Pkg",
@@ -29,13 +30,6 @@
 
     @testset "only specified stdlibs" begin
         kwargs = deepcopy(global_kwargs)
-        result = bump_stdlibs(julia_repo; kwargs...)
-        @test result isa Nothing
-    end
-
-    @testset "override the default branch" begin
-        kwargs = deepcopy(global_kwargs)
-        kwargs[:julia_repo_default_branch] = "master"
         result = bump_stdlibs(julia_repo; kwargs...)
         @test result isa Nothing
     end


### PR DESCRIPTION
Fixes #76