### PR TITLE
Only close old PRs if they have the same target branch as the current run

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -2,5 +2,6 @@ delete_merged_branches = true
 status = [
     "test (1, ubuntu-latest, x64)",
     "test (nightly, ubuntu-latest, x64)",
+    "Documentation",
 ]
 timeout_sec = 3600

--- a/src/bump-stdlibs.jl
+++ b/src/bump-stdlibs.jl
@@ -122,7 +122,7 @@ function _bump_single_stdlib(stdlib::StdlibInfo, config::Config, state::State)
                     cd(joinpath(temp_dir, "FORK")) do
                         run(`git checkout $(config.julia_repo_target_branch)`)
                         assert_current_branch_is(config.julia_repo_target_branch)
-                        pr_title_without_emoji = "Bump the $(stdlib.name) stdlib from $(stdlib_current_commit_in_upstream_short) to $(stdlib_latest_commit_short) on the `$(config.julia_repo_target_branch)` branch"
+                        pr_title_without_emoji = "[$(config.julia_repo_target_branch)] Bump the $(stdlib.name) stdlib from $(stdlib_current_commit_in_upstream_short) to $(stdlib_latest_commit_short)"
                         pr_title = "🤖 $(pr_title_without_emoji)"
                         commit_message = pr_title
                         pr_branch_suffix_stripped = strip(pr_branch_suffix)

--- a/test/integration-tests.jl
+++ b/test/integration-tests.jl
@@ -6,7 +6,7 @@
         :close_old_pull_requests => true,
         :close_old_pull_requests_older_than => Dates.Minute(5),
         :julia_repo_target_branch => "master",
-        :pr_branch_suffix => Random.randstring(4),
+        :pr_branch_suffix => Random.randstring('0':'9', 4),
         :push_if_no_changes => true,
         :stdlibs_to_include => "Pkg",
     )


### PR DESCRIPTION
Fixes #87

## Summary

1. Put the target branch in the PR title.
2. Put the target branch in the PR body.
3. Put the target branch in the PR branch name.
4. When deleting old PR branches, only delete old PR branches that have the same target branch as the current run.

## Details

Before this PR, the PR branches have the following naming convention:

```
BumpStdlibs/StdlibName-commithash123

BumpStdlibs/StdlibName-commithash123-12345 # used in our integration tests to avoid having branches clash with each other
```

```
BumpStdlibs/StdlibName-commithash123-target-branch-name

BumpStdlibs-12345/StdlibName-commithash123-target-branch-name # used in our integration tests to avoid having branches clash with each other
```