### PR TITLE
CI: Migrate from Bors to GitHub Merge Queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,19 @@ concurrency:
 
 jobs:
   integration-tests:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 60
+    #
+    # Because we use GitHub Merge Queue,
+    # the job name of the integration tests
+    # can't interpolate any info like
+    # Julia version number, or operating system.
+    # This constraint applies only to the integration tests.
+    #
+    # Other jobs (like unit tests, and docs)
+    # can have whatever names they want.
+    name: Integration
+    #
     # We don't actually want to run integration tests on pull requests,
     # because we want to avoid hitting rate limits.
     # So, if this is a PR build, mark the integration tests as "skipped".
@@ -24,19 +35,17 @@ jobs:
     strategy:
       fail-fast: false
       max-parallel: 1
-      matrix:
-        version:
-          - '1'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
+      # Note: Because we want to use GitHub Merge Queue,
+      # we can't use a matrix for the integration tests.
+      # This constraint applies only to the integration tests.
+      #
+      # We can still use a matrix for other jobs,
+      # such as unit tests and docs.
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
+          version: '1'
       - uses: julia-actions/cache@v2
       - run: git config --global user.name "Dilum Aluthge"
       - run: git config --global user.email "dilum@aluthge.com"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,11 @@
 name: CI
 
 on:
-  # pull_request: # we use Bors
+  merge_group: # GitHub Merge Queue
+  pull_request:
   push:
     branches:
       - master
-      - staging
-      - trying
     tags: '*'
   workflow_dispatch:
 
@@ -15,9 +14,13 @@ concurrency:
   cancel-in-progress: ${{ (github.ref == 'refs/heads/staging') || (github.ref == 'refs/heads/trying') }}
 
 jobs:
-  test:
+  integration-tests:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+    # We don't actually want to run integration tests on pull requests,
+    # because we want to avoid hitting rate limits.
+    # So, if this is a PR build, mark the integration tests as "skipped".
+    if: github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
       matrix:
         version:
           - '1'
-          - 'nightly'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
The free public instance of Bors has been shut down.