### PR TITLE
CI: Don't run tests on Julia nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         version:
           - '1'
-          - 'nightly'
+          # - 'nightly'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
I don't know if this specific repo gets a lot of benefit from running CI on Julia nightly.

Also, our integration tests take a long time to run, so by removing Julia nightly from the CI matrix, we can speed things up a bit.