### PR TITLE
Commit as the user who triggered the workflow

### DIFF
--- a/.github/workflows/BumpStdlibs.yml
+++ b/.github/workflows/BumpStdlibs.yml
@@ -31,8 +31,8 @@ jobs:
       - uses: julia-actions/setup-julia@v2
       - uses: julia-actions/cache@v2
       - run: echo "BUMPSTDLIBS_STDLIBS_TO_INCLUDE is ${{ github.event.inputs.BUMPSTDLIBS_STDLIBS_TO_INCLUDE }}"
-      - run: git config --global user.name "Dilum Aluthge"
-      - run: git config --global user.email "dilum@aluthge.com"
+      - run: git config --global user.name "${{ github.actor }}"
+      - run: git config --global user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>"
       - run: julia --color=yes --project -e 'using Pkg; Pkg.instantiate(); Pkg.precompile()'
       - run: julia --color=yes --project -e 'using BumpStdlibs; bump_stdlibs("JuliaLang/julia")'
         env:


### PR DESCRIPTION
Same commit author as the [`peter-evans/create-pull-request`](https://github.com/peter-evans/create-pull-request/blob/67ccf781d68cd99b580ae25a5c18a1cc84ffff1f/README.md#action-inputs) workflow.

I also don't understand why the PR author isn't the github actions boy instead of a different user, but that's perhaps for a different PR.