### PR TITLE
Don't show [master] for master. Make message shorter

### DIFF
--- a/src/bump-stdlibs.jl
+++ b/src/bump-stdlibs.jl
@@ -123,7 +123,7 @@ function _bump_single_stdlib(stdlib::StdlibInfo, config::Config, state::State)
                         run(`git checkout $(config.julia_repo_target_branch)`)
                         assert_current_branch_is(config.julia_repo_target_branch)
                         branch_prefix = config.julia_repo_target_branch == "master" ? "" : "[$(config.julia_repo_target_branch)] "
-                        pr_title_without_emoji = "$(branch_prefix)Bump the $(stdlib.name) stdlib from $(stdlib_current_commit_in_upstream_short) to $(stdlib_latest_commit_short)"
+                        pr_title_without_emoji = "$(branch_prefix)Bump $(stdlib.name) stdlib $(stdlib_current_commit_in_upstream_short) → $(stdlib_latest_commit_short)"
                         pr_title = "🤖 $(pr_title_without_emoji)"
                         commit_message = pr_title
                         pr_branch_suffix_stripped = strip(pr_branch_suffix)


### PR DESCRIPTION
Before
```
🤖 [master] Bump the NetworkOptions stdlib from 532992f to 46e14ef
```

This PR on master PRs
```
🤖 Bump NetworkOptions stdlib 532992f → 46e14ef
```

and on backport branches 
```
🤖 [release-1.12] Bump NetworkOptions stdlib 532992f → 46e14ef
```
